### PR TITLE
fix(members): fix template and mail title for email change

### DIFF
--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -128,8 +128,8 @@ exports.triggerEmailChange = async (req, res) => {
 
         await mailer.sendMail({
             to: req.body.new_email,
-            subject: constants.MAIL_SUBJECTS.PASSWORD_RESET,
-            template: 'mail-change.html',
+            subject: constants.MAIL_SUBJECTS.MAIL_CHANGE,
+            template: 'mail_change.html',
             parameters: {
                 token: mailChange.value
             }


### PR DESCRIPTION
fixed 1) template name for email change and 2) email title (both were a mistype).
I'm also working on frontend so will do a few things here as well later.