### PR TITLE
Add missing endpoints

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -142,6 +142,7 @@ CirclesRouter.delete('/', circles.deleteCircle);
 
 // Everything related to a specific circle membership. Auth only.
 CircleMembershipsRouter.use(middlewares.maybeAuthorize, middlewares.ensureAuthorized, fetch.fetchCircle, fetch.fetchCircleMembership);
+CircleMembershipsRouter.get('/', circleMemberships.getMembership);
 CircleMembershipsRouter.put('/', circleMemberships.updateMembership);
 CircleMembershipsRouter.delete('/', circleMemberships.deleteMembership);
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -63,6 +63,7 @@ GeneralRouter.post('/signup/:campaign_id', campaigns.registerUser);
 GeneralRouter.post('/confirm-email', register.confirmEmail);
 GeneralRouter.post('/confirm-email-change', members.confirmEmailChange);
 GeneralRouter.post('/login', login.login);
+GeneralRouter.post('/logout', login.logout);
 GeneralRouter.post('/password_reset', login.passwordReset);
 GeneralRouter.post('/password_confirm', login.passwordConfirm);
 GeneralRouter.post('/renew', login.renew);

--- a/lib/server.js
+++ b/lib/server.js
@@ -119,6 +119,7 @@ BodiesRouter.put('/', bodies.updateBody);
 
 // Everything related to a specific body membership. Auth only.
 BodyMembershipsRouter.use(middlewares.maybeAuthorize, middlewares.ensureAuthorized, fetch.fetchBody, fetch.fetchMembership);
+BodyMembershipsRouter.get('/', bodyMemberships.getMembership);
 BodyMembershipsRouter.put('/', bodyMemberships.updateMembership);
 BodyMembershipsRouter.delete('/', bodyMemberships.deleteMembership);
 

--- a/middlewares/body-memberships.js
+++ b/middlewares/body-memberships.js
@@ -80,6 +80,17 @@ exports.listAllMembershipsWithPermission = async (req, res) => {
     });
 };
 
+exports.getMembership = async (req, res) => {
+    if (!req.permissions.hasPermission('view_members:body')) {
+        return errors.makeForbiddenError(res, 'Permission view_members:body is required, but not present.');
+    }
+
+    return res.json({
+        success: true,
+        data: req.currentBodyMembership
+    });
+};
+
 exports.createMembership = async (req, res) => {
     if (!req.permissions.hasPermission('add_member:body')) {
         return errors.makeForbiddenError(res, 'Permission add_member:body is required, but not present.');

--- a/middlewares/circle-memberships.js
+++ b/middlewares/circle-memberships.js
@@ -63,6 +63,17 @@ exports.createMembership = async (req, res) => {
     });
 };
 
+exports.getMembership = async (req, res) => {
+    if (!req.permissions.hasPermission('view_members:circle')) {
+        return errors.makeForbiddenError(res, 'Permission view_members:circle is required, but not present.');
+    }
+
+    return res.json({
+        success: true,
+        data: req.currentCircleMembership
+    });
+};
+
 exports.updateMembership = async (req, res) => {
     if (!req.permissions.hasPermission('update_members:circle')) {
         return errors.makeForbiddenError(res, 'Permission update_members:circle is required, but not present.');

--- a/middlewares/login.js
+++ b/middlewares/login.js
@@ -182,3 +182,25 @@ module.exports.passwordConfirm = async (req, res) => {
         message: 'Password was changed successfully.'
     });
 };
+
+module.exports.logout = async (req, res) => {
+    const value = req.body.refresh_token;
+    if (!value) {
+        return errors.makeBadRequestError(res, 'Token is not provided.');
+    }
+
+    const token = await RefreshToken.findOne({
+        where: { value }
+    });
+
+    if (!token) {
+        return errors.makeForbiddenError(res, 'Token is not found.');
+    }
+
+    await token.destroy();
+
+    return res.json({
+        success: true,
+        message: 'You are now logged out.'
+    });
+};

--- a/test/api/body-memberships-details.test.js
+++ b/test/api/body-memberships-details.test.js
@@ -1,0 +1,97 @@
+const { startServer, stopServer } = require('../../lib/server.js');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('Body membership details', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should return 404 if the membership is not found', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        const body = await generator.createBody();
+
+        await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
+
+        const res = await request({
+            uri: '/bodies/' + body.id + '/members/1337',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should return 400 if id is not a number', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+        const body = await generator.createBody();
+
+        await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
+
+        const res = await request({
+            uri: '/bodies/' + body.id + '/members/nan',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should fail if no permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken({}, user);
+
+        const body = await generator.createBody();
+        const membership = await generator.createBodyMembership(body, user);
+
+        const res = await request({
+            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should find the membership by id', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
+
+        const body = await generator.createBody();
+        const membership = await generator.createBodyMembership(body, user);
+
+        const res = await request({
+            uri: '/bodies/' + body.id + '/members/' + membership.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body.data.id).toEqual(membership.id);
+    });
+});

--- a/test/api/circle-memberships-details.test.js
+++ b/test/api/circle-memberships-details.test.js
@@ -1,0 +1,97 @@
+const { startServer, stopServer } = require('../../lib/server.js');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('Circle membership details', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should return 404 if the membership is not found', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        const circle = await generator.createCircle();
+
+        await generator.createPermission({ scope: 'global', action: 'view_members', object: 'circle' });
+
+        const res = await request({
+            uri: '/circles/' + circle.id + '/members/1337',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should return 400 if id is not a number', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+        const circle = await generator.createCircle();
+
+        await generator.createPermission({ scope: 'global', action: 'view_members', object: 'circle' });
+
+        const res = await request({
+            uri: '/circles/' + circle.id + '/members/nan',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should fail if no permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken({}, user);
+
+        const circle = await generator.createCircle();
+        const membership = await generator.createCircleMembership(circle, user);
+
+        const res = await request({
+            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should find the membership by id', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'view_members', object: 'circle' });
+
+        const circle = await generator.createCircle();
+        const membership = await generator.createCircleMembership(circle, user);
+
+        const res = await request({
+            uri: '/circles/' + circle.id + '/members/' + membership.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body.data.id).toEqual(membership.id);
+    });
+});

--- a/test/api/logout.test.js
+++ b/test/api/logout.test.js
@@ -1,0 +1,68 @@
+const { startServer, stopServer } = require('../../lib/server.js');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('Logout', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should fail if the token is not found', async () => {
+        const res = await request({
+            uri: '/logout',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: {
+                refresh_token: 'test'
+            }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should fail if token is empty', async () => {
+        await generator.createUser();
+
+        const res = await request({
+            uri: '/logout',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: {}
+        });
+
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should succeed if everything is okay', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createRefreshToken({}, user);
+
+        const res = await request({
+            uri: '/logout',
+            method: 'POST',
+            headers: { 'X-Auth-Token': 'blablabla' },
+            body: {
+                refresh_token: token.value
+            }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('errors');
+    });
+});


### PR DESCRIPTION
Added 3 endpoints that were presented in the old core, but are missing in a new core.
1) GET /bodies/:id/members - returns a single body memberships
2) GET /bodies/:id/members - returns a single circle memberships
3) POST /logout - invalidates a refresh token, effectively logging out user (the access token doesn't need to be invalidated, as it only is valid for 10 minutes). This is different that in the new core (you provide the access token and I've no idea how it was working there), I'll make a PR for the frontend changes. 

\+ added tests for this stuff so we'd have 100% coverage as usual.