### PR TITLE
fix(users): allow saving users with date_of_birth as empty string. Fixes HELP-1258

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -156,6 +156,8 @@ User.beforeValidate(async (user) => {
     if (typeof user.phone === 'string') user.phone = user.phone.trim();
     if (typeof user.address === 'string') user.address = user.address.trim();
     if (typeof user.about_me === 'string') user.about_me = user.about_me.trim();
+
+    if (typeof user.date_of_birth === 'string' && user.date_of_birth === '') user.date_of_birth = null;
 });
 
 async function encryptPassword(user) {

--- a/test/unit/users.test.js
+++ b/test/unit/users.test.js
@@ -97,10 +97,15 @@ describe('Users testing', () => {
         }
     });
 
-    test('should allow empty date_of_birth', async () => {
+    test('should allow null date_of_birth', async () => {
         const user = generator.generateUser();
         delete user.date_of_birth;
 
+        await User.create(user);
+    });
+
+    test('should allow empty string date_of_birth', async () => {
+        const user = generator.generateUser({ date_of_birth: '' });
         await User.create(user);
     });
 


### PR DESCRIPTION
converting `''` to `null` before saving user, otherwise it complains about "Invalid date"