### PR TITLE
fix(users): allow changing primary body. Fixes HELP-1222

### DIFF
--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -93,7 +93,7 @@ exports.setUserActive = async (req, res) => {
 };
 
 exports.setPrimaryBody = async (req, res) => {
-    if (!req.permissions.hasPermission('update:member')) {
+    if (!req.permissions.hasPermission('update:member') && req.user.id !== req.currentUser.id) {
         return errors.makeForbiddenError(res, 'Permission update:member is required, but not present.');
     }
 

--- a/test/api/users-primary-body.test.js
+++ b/test/api/users-primary-body.test.js
@@ -131,10 +131,10 @@ describe('User primary body setting', () => {
             body: { primary_body_id: null }
         });
 
-        expect(res.statusCode).toEqual(403);
-        expect(res.body.success).toEqual(false);
-        expect(res.body).not.toHaveProperty('data');
-        expect(res.body).toHaveProperty('message');
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('data');
     });
 
     test('should work with local permission', async () => {


### PR DESCRIPTION
now you can update your primary body not only if you have update:member permission, but also if you're trying to change your own primary body, which is how it should've worked before.
also fixed a test which was incorrect.