### PR TITLE
fix(members): save mail_confirmed_at when registering user in body. Fixes HELP-1264

### DIFF
--- a/middlewares/bodies.js
+++ b/middlewares/bodies.js
@@ -92,7 +92,12 @@ exports.createMember = async (req, res) => {
         ...req.body,
         password,
         mail_confirmed_at: new Date()
-    }, { fields: constants.FIELDS_TO_UPDATE.USER.CREATE });
+    }, {
+        fields: [
+            ...constants.FIELDS_TO_UPDATE.USER.CREATE,
+            'mail_confirmed_at'
+        ]
+    });
 
     const membership = await BodyMembership.create({
         user_id: user.id,

--- a/test/api/body-members-creating.test.js
+++ b/test/api/body-members-creating.test.js
@@ -160,4 +160,30 @@ describe('Body members creating', () => {
         });
         expect(membershipFromDb).not.toEqual(null);
     });
+
+    test('should set mail_confirmed__at', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'create_member', object: 'body' });
+
+        const body = await generator.createBody();
+        const member = generator.generateUser({ superadmin: true });
+
+        const res = await request({
+            uri: '/bodies/' + body.id + '/create-member',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: member
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('data');
+
+        const userFromDb = await User.findByPk(res.body.data.user_id);
+        expect(userFromDb).not.toEqual(null);
+        expect(userFromDb.mail_confirmed_at).not.toEqual(null);
+    });
 });


### PR DESCRIPTION
Fixes 4.2 of https://myaegee.atlassian.net/browse/HELP-1264

there's a limited set of fields that is updated in the db, and the mail_confirmed_at wasn't there, so I've passed it. also wrote a test that fails without my change and passes now.