### PR TITLE
fix(members): forward transaction when creating user

### DIFF
--- a/models/BodyMembership.js
+++ b/models/BodyMembership.js
@@ -31,7 +31,7 @@ BodyMembership.beforeValidate(async (membership) => {
 });
 
 // Adding a person to a shadow circle after joining the body.
-BodyMembership.afterCreate(async (membership) => {
+BodyMembership.afterCreate(async (membership, options) => {
     const body = await Body.findByPk(membership.body_id);
     if (!body.shadow_circle_id) {
         logger.info('No shadow circle specified for body, not adding person to circle.');
@@ -46,7 +46,7 @@ BodyMembership.afterCreate(async (membership) => {
     await CircleMembership.create({
         circle_id: body.shadow_circle_id,
         user_id: membership.user_id
-    });
+    }, { transaction: options.transaction });
 });
 
 // Deleting all the circle memberships after leaving the body.


### PR DESCRIPTION
probably fixes https://myaegee.atlassian.net/browse/HELP-1265, not sure about that

my theory is: the user is created within the transaction and the circle membership isn't, so it tries to create a circle membership for not existing user, not sure if it's true or not but at least it shouldn't break anything.