### PR TITLE
fix(bodies): passing transaction correctly when deleting a body

### DIFF
--- a/middlewares/bodies.js
+++ b/middlewares/bodies.js
@@ -85,11 +85,12 @@ exports.setBodyStatus = async (req, res) => {
         }
 
         // Deleting all the stuff related to body.
-        await JoinRequest.destroy({ where: { body_id: req.currentBody.id } }, { transaction: t });
-        await BodyMembership.destroy({ where: { body_id: req.currentBody.id } }, { transaction: t });
-        await Circle.destroy({ where: { body_id: req.currentBody.id } }, { transaction: t });
-        await Payment.destroy({ where: { body_id: req.currentBody.id } }, { transaction: t });
+        await JoinRequest.destroy({ where: { body_id: req.currentBody.id }, transaction: t });
+        await BodyMembership.destroy({ where: { body_id: req.currentBody.id }, transaction: t });
+        await Circle.destroy({ where: { body_id: req.currentBody.id }, transaction: t });
+        await Payment.destroy({ where: { body_id: req.currentBody.id }, transaction: t });
     });
+
     return res.json({
         success: true,
         data: req.currentBody


### PR DESCRIPTION
apparently Model.destroy() expects a transaction as a property of the first argument, not second.
this was causing a timeout of a request when trying to delete a body, I assume this should (in theory) fix the core not responding after deleting a body.