### PR TITLE
feat(logs): log request headers

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -34,7 +34,8 @@ const config = {
             'postgres.password',
             'access_token',
             'refresh_token',
-            'bugsnag_key'
+            'bugsnag_key',
+            'cookie'
         ],
         bugsnag_key: process.env.BUGSNAG_KEY_CORE || 'CHANGEME'
     },

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -50,7 +50,8 @@ const filterFields = (body) => {
 
 logger.addSerializers({
     body: (body) => filterFields(body),
-    config: (config) => filterFields(config)
+    config: (config) => filterFields(config),
+    headers: (headers) => filterFields(headers)
 });
 
 module.exports = logger;

--- a/lib/morgan.js
+++ b/lib/morgan.js
@@ -18,6 +18,7 @@ module.exports = morgan((tokens, req, res) => {
         status: tokens.status(req, res),
         length: tokens.res(req, res, 'content-length'),
         'response-time': tokens['response-time'](req, res),
+        headers: req.headers,
         user,
         body
     }, 'Request processed');


### PR DESCRIPTION
I want to understand who/which service is actually doing that much requests to `/members/me` while being unauthorized.

Future to-do things:
- add a `x-service` header (or sth like this) to all requests done from other MyAEGEE services, to identify which service they are going to
- probably reject those requests without this header in the future

This should help us figuring out the logging a bit.