### PR TITLE
feat(general): allow listing and confirming users manually. Fixes MA-77

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -91,6 +91,7 @@ GeneralRouter.post('/campaigns', middlewares.ensureAuthorized, campaigns.createC
 MemberRouter.use(middlewares.maybeAuthorize, middlewares.ensureAuthorized, fetch.fetchUser);
 MemberRouter.get('/my_permissions', myPermissions.getMyPermissions);
 MemberRouter.put('/active', members.setUserActive);
+MemberRouter.post('/confirm', members.confirmUser);
 MemberRouter.put('/primary-body', members.setPrimaryBody);
 MemberRouter.put('/email', members.triggerEmailChange);
 MemberRouter.put('/password', members.setUserPassword);
@@ -174,6 +175,7 @@ PaymentsRouter.put('/', payments.updatePayment);
 PaymentsRouter.delete('/', payments.deletePayment);
 
 server.use(endpointsMetrics.addEndpointMetrics);
+server.get('/members/unconfirmed', middlewares.maybeAuthorize, middlewares.ensureAuthorized, members.listAllUnconfirmedUsers);
 server.use('/members/:user_id', MemberRouter);
 server.use('/bodies/:body_id/members/:membership_id', BodyMembershipsRouter);
 server.use('/bodies/:body_id/join-requests/:request_id', JoinRequestsRouter);

--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -115,8 +115,8 @@ exports.setUserActive = async (req, res) => {
 };
 
 exports.confirmUser = async (req, res) => {
-    if (!req.permissions.hasPermission('confirm:member')) {
-        return errors.makeForbiddenError(res, 'Permission confirm:member is required, but not present.');
+    if (!req.permissions.hasPermission('global:confirm:member')) {
+        return errors.makeForbiddenError(res, 'Permission global:confirm:member is required, but not present.');
     }
 
     await req.currentUser.update({ mail_confirmed_at: new Date() });

--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -25,6 +25,27 @@ exports.listAllUsers = async (req, res) => {
     });
 };
 
+exports.listAllUnconfirmedUsers = async (req, res) => {
+    if (!req.permissions.hasPermission('global:view_unconfirmed:member')) {
+        return errors.makeForbiddenError(res, 'Permission global:view_unconfirmed:member is required, but not present.');
+    }
+
+    const result = await User.findAndCountAll({
+        where: {
+            ...helpers.filterBy(req.query.query, constants.FIELDS_TO_QUERY.MEMBER),
+            mail_confirmed_at: null
+        },
+        ...helpers.getPagination(req.query),
+        order: helpers.getSorting(req.query)
+    });
+
+    return res.json({
+        success: true,
+        data: result.rows,
+        meta: { count: result.count }
+    });
+};
+
 exports.getUser = async (req, res) => {
     if (!req.permissions.hasPermission('view:member') && req.user.id !== req.currentUser.id) {
         return errors.makeForbiddenError(res, 'Permission view:member is required, but not present.');
@@ -87,6 +108,18 @@ exports.setUserActive = async (req, res) => {
     }
 
     await req.currentUser.update({ active: req.body.active });
+    return res.json({
+        success: true,
+        data: req.currentUser
+    });
+};
+
+exports.confirmUser = async (req, res) => {
+    if (!req.permissions.hasPermission('confirm:member')) {
+        return errors.makeForbiddenError(res, 'Permission confirm:member is required, but not present.');
+    }
+
+    await req.currentUser.update({ mail_confirmed_at: new Date() });
     return res.json({
         success: true,
         data: req.currentUser

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -789,6 +789,18 @@ async function createPermissions() {
             object: 'member',
             scope: 'local',
             description: 'Allows to suspend or activate users that are member in the body that you got this permission from'
+        },
+        {
+            action: 'list_unconfirmed',
+            object: 'member',
+            scope: 'global',
+            description: 'Allows to list unconfirmed users'
+        },
+        {
+            action: 'confirm',
+            object: 'member',
+            scope: 'global',
+            description: 'Allows to confirm unconfirmed users manually'
         }
     ], { individualHooks: true, validate: true });
 

--- a/test/api/users-confirmation.test.js
+++ b/test/api/users-confirmation.test.js
@@ -1,0 +1,70 @@
+const { startServer, stopServer } = require('../../lib/server.js');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('User confirmation', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should return 404 if the user is not found', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'confirm', object: 'member' });
+
+        const res = await request({
+            uri: '/members/1337/confirm',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should succeed if everything is okay', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'local', action: 'confirm', object: 'member' });
+
+        const res = await request({
+            uri: '/members/' + user.id + '/confirm',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('data');
+        expect(res.body.data.mail_confirmed_at).not.toEqual(null);
+    });
+
+    test('should fail without permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken({}, user);
+
+        const res = await request({
+            uri: '/members/' + user.id + '/confirm',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+});

--- a/test/api/users-confirmation.test.js
+++ b/test/api/users-confirmation.test.js
@@ -37,7 +37,7 @@ describe('User confirmation', () => {
         const user = await generator.createUser({ superadmin: true });
         const token = await generator.createAccessToken({}, user);
 
-        await generator.createPermission({ scope: 'local', action: 'confirm', object: 'member' });
+        await generator.createPermission({ scope: 'global', action: 'confirm', object: 'member' });
 
         const res = await request({
             uri: '/members/' + user.id + '/confirm',

--- a/test/api/users-unconfirmed-listing.test.js
+++ b/test/api/users-unconfirmed-listing.test.js
@@ -1,0 +1,58 @@
+const { startServer, stopServer } = require('../../lib/server.js');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('Users list', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should fail if no permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken({}, user);
+
+        const res = await request({
+            uri: '/members/unconfirmed',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should succeed when everything is okay', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'view_unconfirmed', object: 'member' });
+
+        const otherUser = await generator.createUser({ mail_confirmed_at: null });
+
+        const res = await request({
+            uri: '/members/unconfirmed',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        console.log(res.body);
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(otherUser.id);
+    });
+});

--- a/test/api/users-unconfirmed-listing.test.js
+++ b/test/api/users-unconfirmed-listing.test.js
@@ -45,8 +45,6 @@ describe('Users list', () => {
             headers: { 'X-Auth-Token': token.value }
         });
 
-        console.log(res.body);
-
         expect(res.statusCode).toEqual(200);
         expect(res.body.success).toEqual(true);
         expect(res.body).toHaveProperty('data');


### PR DESCRIPTION
a) added 2 endpoints: 
1) /members/unconfirmed - list unconfirmed users
2) /members/:id/confirm - confirm users
b) added permissions for seeding
c) added tests