### PR TITLE
chore(postgres): put postgres back to 10

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.4"
 services:
     postgres-core:
         restart: always
-        image: postgres:13
+        image: postgres:10.15
         volumes:
             - postgres-core:/var/lib/postgresql/data
         expose:


### PR DESCRIPTION
Apparently you need to do extra stuff when upgrading postgres versions, per https://www.postgresql.org/docs/current/pgupgrade.html
Postgres 10 will get updates until November 2022 so there is no hurry in updating