### PR TITLE
feat: impr dockerfile build speed; use entrypoint

### DIFF
--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,29 +1,35 @@
+# FIXME use alpine
 FROM node:14
 
 RUN mkdir -p /usr/app/src \
 	&& mkdir -p /usr/app/media \
-	&& mkdir -p /usr/app/scripts
-
-RUN apt-get update
-RUN apt-get install netcat -y
-
-COPY ./docker/core/bootstrap.sh /usr/app/scripts/bootstrap.sh
-COPY ./docker/core/wait.sh /usr/app/scripts/wait.sh
-COPY . /usr/app/src
-RUN mkdir /usr/app/src/state
-
-RUN chown -R node:node /usr/app
+	&& mkdir -p /usr/app/scripts \
+	&& apt-get update \
+  && apt-get install netcat -y
 
 WORKDIR /usr/app/src
+
+COPY package.json /usr/app/src
+
+RUN chown -R node:node /usr/app
 
 USER node
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 ENV PATH="/home/node/.npm-global/bin:${PATH}"
 
-RUN npm install -g --loglevel warn nodemon bunyan && npm cache clean --force
-RUN npm install --loglevel warn
+# FIXME no need for nodemon
+RUN npm install -g --loglevel warn nodemon bunyan \
+    && npm cache clean --force \
+    && npm install --loglevel warn
 
-CMD sh /usr/app/scripts/bootstrap.sh && nodemon -e "js,json" lib/run.js
+COPY --chown=node:node ./docker/core/bootstrap.sh /usr/app/scripts/bootstrap.sh
+COPY --chown=node:node ./docker/core/wait.sh /usr/app/scripts/wait.sh
+COPY --chown=node:node . /usr/app/src
+RUN mkdir /usr/app/src/state
+
+
+ENTRYPOINT [ "/usr/app/scripts/bootstrap.sh" ]
+CMD ["nodemon -e 'js,json' lib/run.js"]
 
 EXPOSE 8084

--- a/docker/core/bootstrap.sh
+++ b/docker/core/bootstrap.sh
@@ -5,3 +5,5 @@ echo "Migrating database..."
 npm run db:migrate
 echo "Seeding database..."
 npm run db:seed
+
+sh -c "${@}"

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -6,7 +6,7 @@ services:
       context: ./${PATH_CORE}/..
       dockerfile: ./docker/core/Dockerfile
     image: aegee/core:dev
-    command: sh -c "sh /usr/app/scripts/bootstrap.sh && nodemon -L -e 'js,json' lib/run.js | bunyan --color"
+    command: "nodemon -L -e 'js,json' lib/run.js | bunyan --color"
     volumes:
       - ./${PATH_CORE}/../config/:/usr/app/src/config
       - ./${PATH_CORE}/../lib/:/usr/app/src/lib


### PR DESCRIPTION
Here it is finally, the 'good dockerfile' I had mentioned somewhere (can you link the issue? so we have some cross-reference).

There are 2 changes here, 
first is that the files are copied last, so that the cache layer of npm install is not invalidated. This means faster builds.
second is the use of ENTRYPOINT along CMD. it's just a good trick to make a docker container execute different stuff based on the argument passed (you see that in dev we add ` | bunyan --color` ).

In general, I am not sure about the use of nodemon, discuss