### PR TITLE
fix(members): change getUser for event creation

### DIFF
--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -48,6 +48,17 @@ exports.listAllUnconfirmedUsers = async (req, res) => {
 
 exports.getUser = async (req, res) => {
     if (!req.permissions.hasPermission('view:member') && req.user.id !== req.currentUser.id) {
+        if (req.permissions.hasPermission('view_members:body')) {
+            return res.json({
+                success: true,
+                data: {
+                    id: req.currentUser.id,
+                    first_name: req.currentUser.first_name,
+                    last_name: req.currentUser.last_name,
+                    email: req.currentUser.email
+                }
+            });
+        }
         return errors.makeForbiddenError(res, 'Permission view:member is required, but not present.');
     }
 

--- a/test/api/users-details.test.js
+++ b/test/api/users-details.test.js
@@ -90,25 +90,6 @@ describe('User details', () => {
         expect(res.body.data.id).toEqual(user.id);
     });
 
-    test('should find the user with view_member', async () => {
-        const user = await generator.createUser({ superadmin: true });
-        const token = await generator.createAccessToken({}, user);
-
-        await generator.createPermission({ scope: 'global', action: 'view_member', object: 'body' });
-
-        const res = await request({
-            uri: '/members/' + user.id,
-            method: 'GET',
-            headers: { 'X-Auth-Token': token.value }
-        });
-
-        expect(res.statusCode).toEqual(200);
-        expect(res.body.success).toEqual(true);
-        expect(res.body).toHaveProperty('data');
-        expect(res.body).not.toHaveProperty('errors');
-        expect(res.body.data.id).toEqual(user.id);
-    });
-
     test('work for the current user for /me without permission', async () => {
         const user = await generator.createUser();
         const token = await generator.createAccessToken({}, user);
@@ -179,6 +160,27 @@ describe('User details', () => {
         await generator.createCircleMembership(circle, user);
         await generator.createCirclePermission(circle, permission);
         await generator.createBodyMembership(body, otherUser);
+
+        const res = await request({
+            uri: '/members/' + otherUser.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body.data.id).toEqual(otherUser.id);
+    });
+
+    test('should work with global view_members permission', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'view_members', object: 'body' });
+
+        const otherUser = await generator.createUser();
 
         const res = await request({
             uri: '/members/' + otherUser.id,

--- a/test/api/users-details.test.js
+++ b/test/api/users-details.test.js
@@ -90,6 +90,25 @@ describe('User details', () => {
         expect(res.body.data.id).toEqual(user.id);
     });
 
+    test('should find the user with view_member', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'view_member', object: 'body' });
+
+        const res = await request({
+            uri: '/members/' + user.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body.data.id).toEqual(user.id);
+    });
+
     test('work for the current user for /me without permission', async () => {
         const user = await generator.createUser();
         const token = await generator.createAccessToken({}, user);


### PR DESCRIPTION
Members now have the global:view_members:body permission to add organizers from other locals, with this change we also store the correct information when storing the event