### PR TITLE
feat(members): add endpoints for searching and retrieving email

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -79,6 +79,8 @@ GeneralRouter.get('/bodies', bodies.listAllBodies);
 GeneralRouter.get('/my_permissions', middlewares.ensureAuthorized, myPermissions.getMyPermissions);
 GeneralRouter.post('/my_permissions', middlewares.ensureAuthorized, myPermissions.getMyCirclesWithPermission);
 GeneralRouter.get('/members', middlewares.ensureAuthorized, members.listAllUsers);
+GeneralRouter.get('/members_search', middlewares.ensureAuthorized, members.searchAllUsers);
+GeneralRouter.get('/members_email', middlewares.ensureAuthorized, members.getUsersEmail);
 GeneralRouter.post('/bodies', middlewares.ensureAuthorized, bodies.createBody);
 GeneralRouter.get('/circles', middlewares.ensureAuthorized, circles.listAllCircles);
 GeneralRouter.post('/circles', middlewares.ensureAuthorized, circles.createCircle);

--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -93,8 +93,18 @@ exports.getUsersEmail = async (req, res) => {
         return errors.makeForbiddenError(res, 'Permission global:mail:member is required, but not present.');
     }
 
+    if (req.query.query && !req.query.query.match(/^\d+(?:,\d+)*$/g)) {
+        return errors.makeBadRequestError(res, 'Query should be a string of 1 id or multiple ids seperated by commas.');
+    }
+
+    let where = {};
+
+    if (typeof req.query.query === 'string' && req.query.query.trim().length > 0) {
+        where = { id: { [Sequelize.Op.or]: req.query.query.split(',') } };
+    }
+
     const result = await User.findAndCountAll({
-        where: { id: { [Sequelize.Op.or]: req.query.query.split(',') } },
+        where,
         attributes: ['id', 'email', 'gsuite_id', 'primary_email', 'notification_email']
     });
 

--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -1,4 +1,5 @@
 const moment = require('moment');
+const _ = require('lodash');
 
 const { User, Body, MailChange } = require('../models');
 const constants = require('../lib/constants');
@@ -110,7 +111,7 @@ exports.getUsersEmail = async (req, res) => {
 
     return res.json({
         success: true,
-        data: result.rows, // TODO: only return id and notification_email
+        data: result.rows.map((row) => _.pick(row, ['id', 'notification_email'])),
         meta: { count: result.count }
     });
 };

--- a/test/api/users-email.test.js
+++ b/test/api/users-email.test.js
@@ -114,29 +114,29 @@ describe('Users list', () => {
         expect(res.body).not.toHaveProperty('data');
     });
 
-    // test('should only return id and notification email', async () => {
-    //     const user = await generator.createUser({ superadmin: true });
-    //     const token = await generator.createAccessToken({}, user);
+    test('should only return id and notification email', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
 
-    //     await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
+        await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
 
-    //     const res = await request({
-    //         uri: '/members_email',
-    //         method: 'GET',
-    //         headers: { 'X-Auth-Token': token.value }
-    //     });
+        const res = await request({
+            uri: '/members_email',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
 
-    //     const expectedOutput = {
-    //         id: user.id,
-    //         notification_email: user.notification_email
-    //     }
+        const expectedOutput = {
+            id: user.id,
+            notification_email: user.notification_email
+        };
 
-    //     expect(res.statusCode).toEqual(200);
-    //     expect(res.body.success).toEqual(true);
-    //     expect(res.body).toHaveProperty('data');
-    //     expect(res.body).not.toHaveProperty('errors');
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
 
-    //     expect(res.body.data.length).toEqual(1);
-    //     expect(res.body.data[0]).toEqual(expectedOutput);
-    // });
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0]).toEqual(expectedOutput);
+    });
 });

--- a/test/api/users-email.test.js
+++ b/test/api/users-email.test.js
@@ -1,0 +1,142 @@
+const { startServer, stopServer } = require('../../lib/server.js');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('Users list', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should fail if no permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken({}, user);
+
+        const res = await request({
+            uri: '/members_email',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should succeed when everything is okay', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
+
+        const res = await request({
+            uri: '/members_email',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(user.id);
+    });
+
+    test('should find one by id', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
+
+        const res = await request({
+            uri: '/members_email?query=' + user.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(user.id);
+    });
+
+    test('should find multiple by id array', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const secondUser = await generator.createUser();
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
+
+        const res = await request({
+            uri: '/members_email?query=' + user.id + ',' + secondUser.id,
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(2);
+        expect([user.id, secondUser.id]).toContainEqual(res.body.data[0].id);
+        expect([user.id, secondUser.id]).toContainEqual(res.body.data[1].id);
+    });
+
+    test('should fail when query is not a string of ids seperated by commas', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
+
+        const res = await request({
+            uri: '/members_email?query=a,b',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    // test('should only return id and notification email', async () => {
+    //     const user = await generator.createUser({ superadmin: true });
+    //     const token = await generator.createAccessToken({}, user);
+
+    //     await generator.createPermission({ scope: 'global', action: 'mail', object: 'member' });
+
+    //     const res = await request({
+    //         uri: '/members_email',
+    //         method: 'GET',
+    //         headers: { 'X-Auth-Token': token.value }
+    //     });
+
+    //     const expectedOutput = {
+    //         id: user.id,
+    //         notification_email: user.notification_email
+    //     }
+
+    //     expect(res.statusCode).toEqual(200);
+    //     expect(res.body.success).toEqual(true);
+    //     expect(res.body).toHaveProperty('data');
+    //     expect(res.body).not.toHaveProperty('errors');
+
+    //     expect(res.body.data.length).toEqual(1);
+    //     expect(res.body.data[0]).toEqual(expectedOutput);
+    // });
+});

--- a/test/api/users-searching.test.js
+++ b/test/api/users-searching.test.js
@@ -1,0 +1,236 @@
+const { startServer, stopServer } = require('../../lib/server.js');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+
+describe('Users list', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+    });
+
+    test('should fail if no permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken({}, user);
+
+        const res = await request({
+            uri: '/members_search',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).toHaveProperty('message');
+        expect(res.body).not.toHaveProperty('data');
+    });
+
+    test('should succeed when everything is okay', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const res = await request({
+            uri: '/members_search',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(user.id);
+    });
+
+    test('should respect limit and offset', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        const member = await generator.createUser();
+        await generator.createUser();
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const res = await request({
+            uri: '/members_search?limit=1&offset=1', // second one should be returned
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).toHaveProperty('meta');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(member.id);
+
+        expect(res.body.meta.count).toEqual(3);
+    });
+
+    test('should respect sorting', async () => {
+        const firstUser = await generator.createUser({
+            first_name: 'aaa',
+            mail_confirmed_at: new Date(),
+            superadmin: true
+        });
+        const token = await generator.createAccessToken({}, firstUser);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const secondUser = await generator.createUser({ first_name: 'bbb' });
+
+        const res = await request({
+            uri: '/members_search?sort=first_name&direction=desc', // second one should be returned
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).toHaveProperty('meta');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(2);
+        expect(res.body.data[0].id).toEqual(secondUser.id);
+        expect(res.body.data[1].id).toEqual(firstUser.id);
+    });
+
+    test('should find by first_name', async () => {
+        const user = await generator.createUser({ superadmin: true, first_name: 'aaa', last_name: 'bbb', email: 'ccc@test.io' });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+        await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
+
+        const res = await request({
+            uri: '/members_search?query=aaa',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(user.id);
+    });
+
+    test('should find by last_name', async () => {
+        const user = await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'aaa', email: 'ccc@test.io' });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+        await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
+
+        const res = await request({
+            uri: '/members_search?query=aaa',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(user.id);
+    });
+
+    test('should find by email', async () => {
+        const user = await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'aaa@test.io' });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+        await generator.createUser({ superadmin: true, first_name: 'zzz', last_name: 'zzz', email: 'zzz@test.io' });
+
+        const res = await request({
+            uri: '/members_search?query=aaa',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0].id).toEqual(user.id);
+    });
+
+    test('should only return certain fields (with GSuite ID)', async () => {
+        const user = await generator.createUser({ superadmin: true, gsuite_id: 'test@aegee.eu' });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const res = await request({
+            uri: '/members_search',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        const expectedOutput = {
+            id: user.id,
+            first_name: user.first_name,
+            last_name: user.last_name,
+            username: user.username,
+            email: user.email,
+            gsuite_id: user.gsuite_id
+        };
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0]).toEqual(expectedOutput);
+    });
+
+    test('should only return certain fields (without GSuite ID)', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken({}, user);
+
+        await generator.createPermission({ scope: 'global', action: 'search', object: 'member' });
+
+        const res = await request({
+            uri: '/members_search',
+            method: 'GET',
+            headers: { 'X-Auth-Token': token.value }
+        });
+
+        const expectedOutput = {
+            id: user.id,
+            first_name: user.first_name,
+            last_name: user.last_name,
+            username: user.username,
+            email: user.email,
+            gsuite_id: user.gsuite_id
+        };
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).toHaveProperty('data');
+        expect(res.body).not.toHaveProperty('errors');
+
+        expect(res.body.data.length).toEqual(1);
+        expect(res.body.data[0]).toEqual(expectedOutput);
+    });
+});


### PR DESCRIPTION
Frontend and other modules will be updated later as well, but nothing will break since only new endpoints are added. searchAllUsers will be used for adding members to a body and other places where you want to add people but don't need all the additional data of that user, currently it all requires view:member for that. getUsersEmail is for the massmailer so with one request we get all current emails.