### PR TITLE
fix(user): delete confirmation with manual

### DIFF
--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -1,6 +1,6 @@
 const moment = require('moment');
 
-const { User, Body, MailChange } = require('../models');
+const { User, Body, MailChange, MailConfirmation } = require('../models');
 const constants = require('../lib/constants');
 const helpers = require('../lib/helpers');
 const errors = require('../lib/errors');
@@ -132,6 +132,13 @@ exports.confirmUser = async (req, res) => {
     }
 
     await req.currentUser.update({ mail_confirmed_at: new Date() });
+
+    const confirmation = await MailConfirmation.findOne({
+        where: { user_id: req.currentUser.id }
+    });
+
+    await confirmation.destroy();
+
     return res.json({
         success: true,
         data: req.currentUser

--- a/test/api/users-confirmation.test.js
+++ b/test/api/users-confirmation.test.js
@@ -38,6 +38,7 @@ describe('User confirmation', () => {
         const token = await generator.createAccessToken({}, user);
 
         await generator.createPermission({ scope: 'global', action: 'confirm', object: 'member' });
+        await generator.createMailConfirmation({ user_id: user.id });
 
         const res = await request({
             uri: '/members/' + user.id + '/confirm',


### PR DESCRIPTION
When you manually confirm a user, the MailConfirmation object is still present. This would trigger the cron job and in 2 days the manually confirmed user would still be deleted. This fixes that.