### PR TITLE
fix(logging): log info and above by default

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -16,7 +16,7 @@ const config = {
         },
         logger: {
             silent: false,
-            level: process.env.LOGLEVEL || 'debug'
+            level: process.env.LOGLEVEL || 'info'
         },
         host: process.env.HOST || 'localhost',
         media_dir: '/usr/app/media',


### PR DESCRIPTION
@serge1peshcoff apparently LOGLEVEL is not set in .env so it does debug. Apart from adding it to .env I think it's good if the default level is also info on production