### PR TITLE
ci(dbap): update docker image for semantic-release update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           failure_message: The audit check for \`$CIRCLE_PROJECT_REPONAME\` has failed.
   docker-build-and-push:
     docker:
-      - image: cimg/node:14.16.0
+      - image: cimg/node:16.13.0
     steps:
       - checkout
       - setup_remote_docker:


### PR DESCRIPTION
https://github.com/AEGEE/core/pull/379 requires a version of Node >14.17 and 16.13 is the current LTS. Will update the other images here later with the updates done in discounts (when I've updated the Slack messages as well since I prefer the old ones)