### PR TITLE
chore(docker): update Node

### DIFF
--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,5 +1,5 @@
 # FIXME use alpine
-FROM node@sha256:14f0471d0478fbb9177d0f9e8c146dc872273dcdcfc7fea93a27ed81fc6b0e96
+FROM node:18.16.1
 
 RUN mkdir -p /usr/app/src \
 	&& mkdir -p /usr/app/media \

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -1,5 +1,5 @@
 # FIXME use alpine
-FROM node:18.16.1
+FROM node:18.16.1@sha256:f4698d49371c8a9fa7dd78b97fb2a532213903066e47966542b3b1d403449da4
 
 RUN mkdir -p /usr/app/src \
 	&& mkdir -p /usr/app/media \


### PR DESCRIPTION
It seems that the sha tag is actually for Node 20.2.0