### PR TITLE
ci: only run scorecard analysis on pushing to stable

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -13,8 +13,6 @@ on:
     - cron: '35 8 * * 4'
   push:
     branches: ["stable"]
-  pull_request:
-    branches: ["stable"]
 
 # Declare default permissions as read only.
 permissions: read-all


### PR DESCRIPTION
Otherwise branch_protection rules goes wrong