### PR TITLE
feat(member): add subscribe to listserv

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -14,6 +14,9 @@ const config = {
             url: 'http://mailer',
             port: 4000
         },
+        listserv_email: [
+            process.env.LISTSERV_EMAIL || 'listserv@example.com'
+        ],
         logger: {
             silent: false,
             level: process.env.LOGLEVEL || 'info'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,7 @@ services:
             HOST: "${SUBDOMAIN_FRONTEND}${BASE_URL}"
             CORE_LOGIN: "${CORE_LOGIN}"
             CORE_PASSWORD: "${CORE_PASSWORD}"
+            LISTSERV_EMAIL: "${LISTSERV_EMAIL}"
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:8084/healthcheck"]
             interval: 30s

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -184,6 +184,13 @@ function getRandomBytes(length) {
     });
 }
 
+function getMailText({ user, mailinglists }) {
+    return `OK BEGIN
+REG ${user.first_name} ${user.last_name}
+SUBSCRIBE ${mailinglists.join('\nSUBSCRIBE ')}
+OK END`;
+}
+
 // A helper to add data to gauge Prometheus metric.
 const addGaugeData = (gauge, array) => {
     // reset gauge...
@@ -209,5 +216,6 @@ module.exports = {
     findBy,
     whitelistObject,
     getRandomBytes,
+    getMailText,
     addGaugeData
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -98,6 +98,7 @@ MemberRouter.post('/confirm', members.confirmUser);
 MemberRouter.put('/primary-body', members.setPrimaryBody);
 MemberRouter.put('/email', members.triggerEmailChange);
 MemberRouter.put('/password', members.setUserPassword);
+MemberRouter.post('/listserv', members.subscribeListserv);
 MemberRouter.get('/', members.getUser);
 MemberRouter.put('/', members.updateUser);
 MemberRouter.delete('/', members.deleteUser);

--- a/middlewares/members.js
+++ b/middlewares/members.js
@@ -334,6 +334,6 @@ exports.subscribeListserv = async (req, res) => {
 
     return res.json({
         success: true,
-        message: `Check your email to confirm your subscription to ${mailinglists.join(', ')}.`
+        message: `Request for subscribing to ${mailinglists.join(', ')} has been sent.`
     });
 };

--- a/test/api/users-listserv.test.js
+++ b/test/api/users-listserv.test.js
@@ -135,7 +135,7 @@ describe('User subscribe listserv', () => {
         expect(res.body.success).toEqual(true);
         expect(res.body).not.toHaveProperty('errors');
         expect(res.body).toHaveProperty('message');
-        expect(res.body.message).toEqual('Check your email to confirm your subscription to ANNOUNCE-L.');
+        expect(res.body.message).toEqual('Request for subscribing to ANNOUNCE-L has been sent.');
     });
 
     test('should succeed for multiple mailinglists if everything is okay', async () => {
@@ -155,7 +155,7 @@ describe('User subscribe listserv', () => {
         expect(res.body.success).toEqual(true);
         expect(res.body).not.toHaveProperty('errors');
         expect(res.body).toHaveProperty('message');
-        expect(res.body.message).toEqual('Check your email to confirm your subscription to ANNOUNCE-L, AEGEE-L, AEGEE-NEWS-L.');
+        expect(res.body.message).toEqual('Request for subscribing to ANNOUNCE-L, AEGEE-L, AEGEE-NEWS-L has been sent.');
     });
 
     test('should work for current user for /me without permission', async () => {

--- a/test/api/users-listserv.test.js
+++ b/test/api/users-listserv.test.js
@@ -148,14 +148,14 @@ describe('User subscribe listserv', () => {
             uri: '/members/' + user.id + '/listserv',
             method: 'POST',
             headers: { 'X-Auth-Token': token.value },
-            body: { mailinglists: ['announce-l, AEGEE-L, AeGeE-NeWs-L'] }
+            body: { mailinglists: ['announce-l, AEGEE-L, AeGeEnEwS-l'] }
         });
 
         expect(res.statusCode).toEqual(200);
         expect(res.body.success).toEqual(true);
         expect(res.body).not.toHaveProperty('errors');
         expect(res.body).toHaveProperty('message');
-        expect(res.body.message).toEqual('Request for subscribing to ANNOUNCE-L, AEGEE-L, AEGEE-NEWS-L has been sent.');
+        expect(res.body.message).toEqual('Request for subscribing to ANNOUNCE-L, AEGEE-L, AEGEENEWS-L has been sent.');
     });
 
     test('should work for current user for /me without permission', async () => {

--- a/test/api/users-listserv.test.js
+++ b/test/api/users-listserv.test.js
@@ -1,0 +1,238 @@
+const { startServer, stopServer } = require('../../lib/server');
+const { request } = require('../scripts/helpers');
+const generator = require('../scripts/generator');
+const mock = require('../scripts/mock');
+
+describe('User subscribe listserv', () => {
+    beforeAll(async () => {
+        await startServer();
+    });
+
+    afterAll(async () => {
+        await stopServer();
+    });
+
+    beforeEach(async () => {
+        await mock.mockAll();
+    });
+
+    afterEach(async () => {
+        await generator.clearAll();
+        await mock.cleanAll();
+    });
+
+    test('should return 404 if the user is not found', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
+
+        const res = await request({
+            uri: '/members/1337/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['ANNOUNCE-L'] }
+        });
+
+        expect(res.statusCode).toEqual(404);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should fail if mailinglists is not provided', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: {}
+        });
+
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should fail if there mailinglists is not an array', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: 'not-valid' }
+        });
+
+        expect(res.statusCode).toEqual(400);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should fail if there mailinglists is an empty array', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: [] }
+        });
+
+        expect(res.statusCode).toEqual(422);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should fail if mailer fails', async () => {
+        mock.mockAll({ mailer: { netError: true } });
+
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['ANNOUNCE-L'] }
+        });
+
+        expect(res.statusCode).toEqual(500);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should succeed for one mailinglist if everything is okay', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['ANNOUNCE-L'] }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('message');
+        expect(res.body.message).toEqual('Check your email to confirm your subscription to ANNOUNCE-L.');
+    });
+
+    test('should succeed for multiple mailinglists if everything is okay', async () => {
+        const user = await generator.createUser({ superadmin: true });
+        const token = await generator.createAccessToken(user);
+
+        await generator.createPermission({ scope: 'global', action: 'subscribe', object: 'listserv' });
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['announce-l, AEGEE-L, AeGeE-NeWs-L'] }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('message');
+        expect(res.body.message).toEqual('Check your email to confirm your subscription to ANNOUNCE-L, AEGEE-L, AEGEE-NEWS-L.');
+    });
+
+    test('should work for current user for /me without permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['ANNOUNCE-L'] }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should work for current user for /:user_id without permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        const res = await request({
+            uri: '/members/' + user.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['ANNOUNCE-L'] }
+        });
+
+        expect(res.statusCode).toEqual(200);
+        expect(res.body.success).toEqual(true);
+        expect(res.body).not.toHaveProperty('errors');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should not work with local permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        const otherUser = await generator.createUser();
+        const permission = await generator.createPermission({ scope: 'local', action: 'suscribe', object: 'listserv' });
+        const body = await generator.createBody();
+        const circle = await generator.createCircle({ body_id: body.id });
+        await generator.createCircleMembership(circle, user);
+        await generator.createCirclePermission(circle, permission);
+        await generator.createBodyMembership(body, otherUser);
+
+        const res = await request({
+            uri: '/members/' + otherUser.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['ANNOUNCE-L'] }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+
+    test('should fail if no permission', async () => {
+        const user = await generator.createUser();
+        const token = await generator.createAccessToken(user);
+
+        const otherUser = await generator.createUser();
+
+        const res = await request({
+            uri: '/members/' + otherUser.id + '/listserv',
+            method: 'POST',
+            headers: { 'X-Auth-Token': token.value },
+            body: { mailinglists: ['ANNOUNCE-L'] }
+        });
+
+        expect(res.statusCode).toEqual(403);
+        expect(res.body.success).toEqual(false);
+        expect(res.body).not.toHaveProperty('data');
+        expect(res.body).toHaveProperty('message');
+    });
+});


### PR DESCRIPTION
This will be executed by the frontend when applying for a statutory event (and later also in other places). That PR will follow later, this should be enough to test it with the actual listserv. There is a corresponding PR towards the main MyAEGEE repo to update the .env.example