### PR TITLE
feat(body): add google_group

### DIFF
--- a/migrations/20240121174745-add-google-group-to-bodies.js
+++ b/migrations/20240121174745-add-google-group-to-bodies.js
@@ -1,0 +1,12 @@
+module.exports = {
+    up: (queryInterface, Sequelize) => queryInterface.addColumn(
+        'bodies',
+        'google_group',
+        {
+            type: Sequelize.STRING,
+            allowNull: true,
+            unique: true
+        },
+    ),
+    down: (queryInterface) => queryInterface.removeColumn('bodies', 'google_group')
+};

--- a/models/Body.js
+++ b/models/Body.js
@@ -119,6 +119,14 @@ const Body = sequelize.define('body', {
             isEmail: { msg: 'GSuite ID must be a valid email.' }
         },
         unique: true
+    },
+    google_group: {
+        type: Sequelize.STRING,
+        allowNull: true,
+        validate: {
+            isEmail: { msg: 'Google Group must be a valid email.' }
+        },
+        unique: true
     }
 }, {
     underscored: true,
@@ -132,6 +140,7 @@ Body.beforeValidate(async (body) => {
     if (typeof body.code === 'string') body.code = body.code.toUpperCase().trim();
     if (typeof body.email === 'string') body.email = body.email.toLowerCase().trim();
     if (typeof body.gsuite_id === 'string') body.gsuite_id = body.gsuite_id.toLowerCase().trim();
+    if (typeof body.google_group === 'string') body.google_group = body.google_group.toLowerCase().trim();
 
     if (typeof body.abbreviation === 'string') body.abbreviation = body.abbreviation.trim();
 });


### PR DESCRIPTION
This adds a new field to the body, a Google Group.

Bodies usually have three mail addresses, two of them they get from us;
- Own contact email (something like contact@aegee-city.com or aegee-city@gmail.com)
- Google Workspace account for the board (aegee-city@aegee.eu)
- Google Group with the above two email addresses (city@aegee.eu)

With this change we can store all three in core. And with the frontend PR we can also add those manually (when you have the global permission to update a body). Later on the gsuite-wrapper will create those accounts based on the name of the body and sets them.

Frontend PR for that is here; https://github.com/AEGEE/frontend/pull/2024